### PR TITLE
ci: speed up e2e (split jobs, caching, cancel in progress)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,17 @@ name: e2e
 on:
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      runCrud:
+        description: 'Run CRUD job'
+        required: false
+        default: 'false'
+      runNightly:
+        description: 'Run nightly-full'
+        required: false
+        default: 'false'
   schedule:
     - cron: "22 18 * * *" # JST03:22頃にnightly-full
 
@@ -20,13 +31,11 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
-
       - name: Cache wp-now WordPress versions
         uses: actions/cache@v4
         with:
@@ -34,16 +43,12 @@ jobs:
           key: wpnow-${{ runner.os }}-wp682
           restore-keys: |
             wpnow-${{ runner.os }}-
-
       - name: Install deps
         run: npm ci
-
       - name: MU sync
         run: npm run mu:sync
-
       - name: Start wp-now + health wait
         run: bash scripts/wp-start.sh
-
       - name: Smoke tests
         run: npm run test:smoke
 
@@ -51,9 +56,10 @@ jobs:
     needs: smoke
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: >-
+    if: |
       github.event_name == 'schedule' ||
-      contains(join(github.event.pull_request.labels.*.name, ','), 'run-crud')
+      (github.event_name == 'workflow_dispatch' && inputs.runCrud == 'true') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-crud'))
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -82,10 +88,12 @@ jobs:
         run: npm run test:crud
 
   nightly-full:
-    if: github.event_name == 'schedule'
     needs: smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.runNightly == 'true')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,73 +1,114 @@
 name: e2e
+
 on:
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: "22 18 * * *" # JST03:22頃にnightly-full
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
+
+      - name: Cache wp-now WordPress versions
+        uses: actions/cache@v4
+        with:
+          path: ~/.wp-now/wordpress-versions
+          key: wpnow-${{ runner.os }}-wp682
+          restore-keys: |
+            wpnow-${{ runner.os }}-
 
       - name: Install deps
         run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-
       - name: MU sync
         run: npm run mu:sync
 
-      - name: Start wp-now, wait, run tests (single step)
-        shell: bash
-        run: |
-          set -euo pipefail
-          BASE_URL="${BASE_URL:-http://127.0.0.1:8888}"
+      - name: Start wp-now + health wait
+        run: bash scripts/wp-start.sh
 
-          pkill -f '@wp-now/wp-now' 2>/dev/null || true
-          setsid npx -y @wp-now/wp-now start --port 8888 >/tmp/wp-now.log 2>&1 &
+      - name: Smoke tests
+        run: npm run test:smoke
 
-          ok_home=0
-          for i in {1..90}; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/" || echo 000)
-            echo "health=$code"
-            if [ "$code" = "200" ] || [ "$code" = "301" ]; then ok_home=1; break; fi
-            sleep 1
-          done
-          if [ "$ok_home" -ne 1 ]; then
-            echo "Home did not become healthy (200/301) within timeout"
-            exit 1
-          fi
+  crud:
+    needs: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: >-
+      github.event_name == 'schedule' ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'run-crud')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
+      - name: Cache wp-now WordPress versions
+        uses: actions/cache@v4
+        with:
+          path: ~/.wp-now/wordpress-versions
+          key: wpnow-${{ runner.os }}-wp682
+          restore-keys: |
+            wpnow-${{ runner.os }}-
+      - name: Install deps
+        run: npm ci
+      - name: MU sync
+        run: npm run mu:sync
+      - name: Start wp-now + health wait
+        run: bash scripts/wp-start.sh
+      - name: CRUD tests
+        run: npm run test:crud
 
-          ok_ping=0
-          for i in {1..90}; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/wp-json/mb-qa/v1/ping" || echo 000)
-            echo "ping=$code"
-            if [ "$code" = "200" ]; then ok_ping=1; break; fi
-            sleep 1
-          done
-          if [ "$ok_ping" -ne 1 ]; then
-            echo "REST ping did not return 200 within timeout"
-            exit 1
-          fi
-
-          curl -sI "$BASE_URL/" | tr -d '\r' | grep -i 'x-mb-ok' || true
-          curl -sS "$BASE_URL/wp-json/mb-qa/v1/ping" || true
-          curl -sS "$BASE_URL/monthly-estimate/" | grep -n 'id="room_id"' || true
-          curl -sS -X POST -d 'action=mb_qa_echo' "$BASE_URL/wp-admin/admin-ajax.php" -D - | tr -d '\r' | sed -n '1,20p' || true
-
-          BASE_URL="$BASE_URL" \
-            npx playwright test \
-              -c test-environment/playwright/playwright.config.js \
-              test-environment/playwright/tests/mu_smoke.spec.js \
-              test-environment/playwright/tests/smoke_min.spec.js \
-              --project=chromium --workers=1 --reporter=list --trace=on
-
-      - name: Tail wp-now log (always)
-        if: always()
-        run: |
-          echo '---- /tmp/wp-now.log (last 200 lines) ----'
-          tail -n 200 /tmp/wp-now.log || true
+  nightly-full:
+    if: github.event_name == 'schedule'
+    needs: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
+      - name: Cache wp-now WordPress versions
+        uses: actions/cache@v4
+        with:
+          path: ~/.wp-now/wordpress-versions
+          key: wpnow-${{ runner.os }}-wp682
+          restore-keys: |
+            wpnow-${{ runner.os }}-
+      - name: Install deps
+        run: npm ci
+      - name: MU sync
+        run: npm run mu:sync
+      - name: Start wp-now + health wait
+        run: bash scripts/wp-start.sh
+      - name: Full CRUD suite
+        run: npm run test:crud

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,11 +31,21 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+
+      # Playwright browsers cache
       - name: Cache Playwright browsers
+        id: pwcache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
+
+      # If cache miss, install Chromium only (fast)
+      - name: Install Playwright browsers (if cache miss)
+        if: steps.pwcache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      # wp-now WordPress versions cache
       - name: Cache wp-now WordPress versions
         uses: actions/cache@v4
         with:
@@ -43,12 +53,16 @@ jobs:
           key: wpnow-${{ runner.os }}-wp682
           restore-keys: |
             wpnow-${{ runner.os }}-
+
       - name: Install deps
         run: npm ci
+
       - name: MU sync
         run: npm run mu:sync
+
       - name: Start wp-now + health wait
         run: bash scripts/wp-start.sh
+
       - name: Smoke tests
         run: npm run test:smoke
 
@@ -59,18 +73,25 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.runCrud == 'true') ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-crud'))
+      (github.event_name == 'pull_request' && contains(join(github.event.pull_request.labels.*.name, ','), 'run-crud'))
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
       - name: Cache Playwright browsers
+        id: pwcache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers (if cache miss)
+        if: steps.pwcache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
       - name: Cache wp-now WordPress versions
         uses: actions/cache@v4
         with:
@@ -78,14 +99,24 @@ jobs:
           key: wpnow-${{ runner.os }}-wp682
           restore-keys: |
             wpnow-${{ runner.os }}-
+
       - name: Install deps
         run: npm ci
+
       - name: MU sync
         run: npm run mu:sync
+
       - name: Start wp-now + health wait
         run: bash scripts/wp-start.sh
+
+      # Run CRUD tests if script exists; otherwise skip gracefully
       - name: CRUD tests
-        run: npm run test:crud
+        run: |
+          if npm run | grep -q "test:crud"; then
+            npm run test:crud
+          else
+            echo "No test:crud script found; skipping CRUD suite on this PR."
+          fi
 
   nightly-full:
     needs: smoke
@@ -100,11 +131,18 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+
       - name: Cache Playwright browsers
+        id: pwcache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers (if cache miss)
+        if: steps.pwcache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
       - name: Cache wp-now WordPress versions
         uses: actions/cache@v4
         with:
@@ -112,11 +150,20 @@ jobs:
           key: wpnow-${{ runner.os }}-wp682
           restore-keys: |
             wpnow-${{ runner.os }}-
+
       - name: Install deps
         run: npm ci
+
       - name: MU sync
         run: npm run mu:sync
+
       - name: Start wp-now + health wait
         run: bash scripts/wp-start.sh
-      - name: Full CRUD suite
-        run: npm run test:crud
+
+      - name: Full CRUD suite (skip gracefully if missing)
+        run: |
+          if npm run | grep -q "test:crud"; then
+            npm run test:crud
+          else
+            echo "No test:crud script found; skipping nightly CRUD suite."
+          fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,18 +32,13 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      # Playwright browsers cache
+      # Caches (任意だが速くなる)
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
 
-      # ✅ Always ensure the right Chromium is present (cache-aware & idempotent)
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      # wp-now WordPress versions cache
       - name: Cache wp-now WordPress versions
         uses: actions/cache@v4
         with:
@@ -52,8 +47,13 @@ jobs:
           restore-keys: |
             wpnow-${{ runner.os }}-
 
+      # ✅ 先に依存を入れる（ここ重要）
       - name: Install deps
         run: npm ci
+
+      # ✅ 依存が入った後で Playwright ブラウザを入れる（バージョン整合）
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: MU sync
         run: npm run mu:sync
@@ -85,10 +85,6 @@ jobs:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
 
-      # ✅ Always install (fast if cached)
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
       - name: Cache wp-now WordPress versions
         uses: actions/cache@v4
         with:
@@ -97,8 +93,12 @@ jobs:
           restore-keys: |
             wpnow-${{ runner.os }}-
 
+      # ✅ 依存 → ブラウザの順
       - name: Install deps
         run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: MU sync
         run: npm run mu:sync
@@ -106,7 +106,7 @@ jobs:
       - name: Start wp-now + health wait
         run: bash scripts/wp-start.sh
 
-      # Run CRUD tests if script exists; otherwise skip gracefully
+      # test:crud が無い場合はスキップ（落とさない）
       - name: CRUD tests
         run: |
           if npm run | grep -q "test:crud"; then
@@ -135,10 +135,6 @@ jobs:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
 
-      # ✅ Always install (fast if cached)
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
       - name: Cache wp-now WordPress versions
         uses: actions/cache@v4
         with:
@@ -147,8 +143,12 @@ jobs:
           restore-keys: |
             wpnow-${{ runner.os }}-
 
+      # ✅ 依存 → ブラウザの順
       - name: Install deps
         run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: MU sync
         run: npm run mu:sync

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,15 +34,13 @@ jobs:
 
       # Playwright browsers cache
       - name: Cache Playwright browsers
-        id: pwcache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
 
-      # If cache miss, install Chromium only (fast)
-      - name: Install Playwright browsers (if cache miss)
-        if: steps.pwcache.outputs.cache-hit != 'true'
+      # ✅ Always ensure the right Chromium is present (cache-aware & idempotent)
+      - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       # wp-now WordPress versions cache
@@ -82,14 +80,13 @@ jobs:
           cache: 'npm'
 
       - name: Cache Playwright browsers
-        id: pwcache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
 
-      - name: Install Playwright browsers (if cache miss)
-        if: steps.pwcache.outputs.cache-hit != 'true'
+      # ✅ Always install (fast if cached)
+      - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: Cache wp-now WordPress versions
@@ -133,14 +130,13 @@ jobs:
           cache: 'npm'
 
       - name: Cache Playwright browsers
-        id: pwcache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml') }}
 
-      - name: Install Playwright browsers (if cache miss)
-        if: steps.pwcache.outputs.cache-hit != 'true'
+      # ✅ Always install (fast if cached)
+      - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: Cache wp-now WordPress versions


### PR DESCRIPTION
(aside) This PR is CI-only and human-maintained. Devin: please ignore auto-replies here.

## What / Why
- Replace `.github/workflows/e2e.yml` to split jobs (smoke / crud / nightly), add caching (npm / Playwright / wp-now), and cancel in-progress runs for faster CI.

## Changes
- Add `concurrency` to cancel older runs
- Cache: `~/.cache/ms-playwright`, `~/.wp-now/wordpress-versions`, npm
- Jobs: `smoke` (always), `crud` (via label `run-crud` or nightly), `nightly-full` (scheduled)

## Validation
- On this PR: **smoke** runs automatically and should pass quickly
- To run CRUD now: add label **run-crud** then trigger a new run (push an empty commit)

## Risk
- CI-only changes. No runtime code touched. Easy to revert.
